### PR TITLE
Fix CSV parsing problems

### DIFF
--- a/progress2span.erl
+++ b/progress2span.erl
@@ -524,7 +524,7 @@ print_nl(O, false) ->
 read_progress_csv(<<"">>) ->
     empty;
 read_progress_csv(Line) ->
-    Fields0 = string:split(string:chomp(Line), ",", all),
+    Fields0 = re:split(string:chomp(Line), ",(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)"),
     case [unquote(string:trim(Field)) || Field <- Fields0] of
         %% Skip title line
         [<<"TIMESTAMP">>, <<"TID">>|_] ->

--- a/progress2span.erl
+++ b/progress2span.erl
@@ -793,7 +793,8 @@ addmap(Map, Key, ValueStr, Type) ->
                 float ->
                     to_float(ValueStr);
                 timestamp ->
-                    calendar:rfc3339_to_system_time(binary_to_list(ValueStr),
+                    %% Append UTC timezone to timestamps from CSV
+                    calendar:rfc3339_to_system_time(binary_to_list(ValueStr) ++ "Z",
                                                     [{unit,microsecond}]);
                 string when is_atom(ValueStr) ->
                     atom_to_binary(ValueStr, utf8);


### PR DESCRIPTION
Using NSO 5.3, I found two problems parsing a progress trace CSV:
1. Splitting CSV on `,` is too naive, it is valid for a comma to appear in a quoted string.
2. Timestamps in the trace file do not include timezone info (either "+XX:00" or "Z") and the code can't deal with that.

For 1, I just copied a regex off of SO, hope it works :). I'm not sure what happened with 2, I'm running Erlang/OTP 22 FWIW.

